### PR TITLE
bridge_track: properly flush fdb for ports 

### DIFF
--- a/bridge_track.c
+++ b/bridge_track.c
@@ -571,16 +571,30 @@ static int br_set_state(struct rtnl_handle *rth, unsigned ifindex, __u8 state)
     return rtnl_talk(rth, &req.n, 0, 0, NULL, NULL, NULL);
 }
 
-static int br_flush_port(char *ifname)
+static int br_flush_port(struct rtnl_handle *rth, unsigned br_ifindex, unsigned port_ifindex, int vid)
 {
-    char fname[128];
-    snprintf(fname, sizeof(fname), SYSFS_CLASS_NET "/%s/brport/flush", ifname);
-    int fd = open(fname, O_WRONLY);
-    TSTM(0 <= fd, -1, "Couldn't open flush file %s for write: %m", fname);
-    int write_result = write(fd, "1", 1);
-    close(fd);
-    TST(1 == write_result, -1);
-    return 0;
+    struct
+    {
+        struct nlmsghdr n;
+        struct ndmsg ndm;
+        char buf[256];
+    } req;
+
+    memset(&req, 0, sizeof(req));
+
+    req.n.nlmsg_len = NLMSG_LENGTH(sizeof(struct ndmsg));
+    req.n.nlmsg_flags = NLM_F_REQUEST | NLM_F_BULK;
+    req.n.nlmsg_type = RTM_DELNEIGH;
+    req.ndm.ndm_family = PF_BRIDGE;
+    req.ndm.ndm_ifindex = br_ifindex;
+
+    req.ndm.ndm_flags = NTF_SELF;
+
+    addattr32(&req.n, sizeof(req.buf), NDA_IFINDEX, port_ifindex);
+    if (vid > -1)
+	    addattr16(&req.n, sizeof(req), NDA_VLAN, vid);
+
+    return rtnl_talk(rth, &req.n, 0, 0, NULL, NULL, NULL);
 }
 
 static int br_set_ageing_time(char *brname, unsigned int ageing_time)
@@ -673,9 +687,27 @@ void MSTP_OUT_flush_all_fids(per_tree_port_t * ptp)
     bridge_t *br = prt->bridge;
 
     /* Translate CIST flushing to the kernel bridge code */
-    if(0 == ptp->MSTID)
+    if(have_per_vlan_state)
+    {
+        int i;
+
+        for (i = 1; i <= MAX_VID; i++)
+        {
+            __u16 fid = br->vid2fid[i];
+
+            if (br->fid2mstid[fid] != ptp->MSTID)
+                continue;
+
+            if (prt->sysdeps.vlan_state[i] == VLAN_STATE_UNASSIGNED)
+                continue;
+
+            if(0 > br_flush_port(&rth_state, br->sysdeps.if_index, prt->sysdeps.if_index, i))
+               ERROR_PRTNAME(br, prt, "Couldn't flush kernel bridge forwarding database for vid %i", i);
+        }
+    }
+    else if(0 == ptp->MSTID)
     { /* CIST */
-        if(0 > br_flush_port(prt->sysdeps.name))
+        if(0 > br_flush_port(&rth_state, br->sysdeps.if_index, prt->sysdeps.if_index, -1))
             ERROR_PRTNAME(br, prt,
                           "Couldn't flush kernel bridge forwarding database");
     }

--- a/libnetlink.c
+++ b/libnetlink.c
@@ -507,41 +507,35 @@ int rtnl_from_file(FILE * rtnl, rtnl_filter_t handler, void *jarg)
 	}
 }
 
-int addattr32(struct nlmsghdr *n, int maxlen, int type, __u32 data)
+int addattr(struct nlmsghdr *n, int maxlen, int type)
 {
-	int len = RTA_LENGTH(4);
-	struct rtattr *rta;
-	if (NLMSG_ALIGN(n->nlmsg_len) + len > maxlen) {
-		ERROR(
-			"addattr32: Error! max allowed bound %d exceeded\n",
-			maxlen);
-		return -1;
-	}
-	rta = NLMSG_TAIL(n);
-	rta->rta_type = type;
-	rta->rta_len = len;
-	memcpy(RTA_DATA(rta), &data, 4);
-	n->nlmsg_len = NLMSG_ALIGN(n->nlmsg_len) + len;
-	return 0;
+	return addattr_l(n, maxlen, type, NULL, 0);
 }
 
 int addattr8(struct nlmsghdr *n, int maxlen, int type, __u8 data)
 {
-	int len = RTA_LENGTH(1);
-	struct rtattr *rta;
-	if (NLMSG_ALIGN(n->nlmsg_len) + len > maxlen) {
-		ERROR(
-			"addattr8: Error! max allowed bound %d exceeded\n",
-			maxlen);
-		return -1;
-	}
-	rta = NLMSG_TAIL(n);
-	rta->rta_type = type;
-	rta->rta_len = len;
-	memcpy(RTA_DATA(rta), &data, 1);
-	n->nlmsg_len = NLMSG_ALIGN(n->nlmsg_len) + len;
-	return 0;
+	return addattr_l(n, maxlen, type, &data, sizeof(__u8));
 }
+
+int addattr16(struct nlmsghdr *n, int maxlen, int type, __u16 data)
+{
+	return addattr_l(n, maxlen, type, &data, sizeof(__u16));
+}
+
+int addattr32(struct nlmsghdr *n, int maxlen, int type, __u32 data)
+{
+	return addattr_l(n, maxlen, type, &data, sizeof(__u32));
+}
+
+int addattr64(struct nlmsghdr *n, int maxlen, int type, __u64 data)
+{
+	return addattr_l(n, maxlen, type, &data, sizeof(__u64));
+}
+
+int addattrstrz(struct nlmsghdr *n, int maxlen, int type, const char *str)
+{
+	return addattr_l(n, maxlen, type, str, strlen(str)+1);
+ }
 
 int addattr_l(struct nlmsghdr *n, int maxlen, int type, const void *data,
 	      int alen)

--- a/libnetlink.h
+++ b/libnetlink.h
@@ -34,8 +34,13 @@ int rtnl_talk(struct rtnl_handle *rtnl, struct nlmsghdr *n, pid_t peer,
               void *jarg);
 int rtnl_send(struct rtnl_handle *rth, const char *buf, int);
 
+int addattr(struct nlmsghdr *n, int maxlen, int type);
 int addattr8(struct nlmsghdr *n, int maxlen, int type, __u8 data);
+int addattr16(struct nlmsghdr *n, int maxlen, int type, __u16 data);
 int addattr32(struct nlmsghdr *n, int maxlen, int type, __u32 data);
+int addattr64(struct nlmsghdr *n, int maxlen, int type, __u64 data);
+int addattrstrz(struct nlmsghdr *n, int maxlen, int type, const char *data);
+
 int addattr_l(struct nlmsghdr *n, int maxlen, int type, const void *data,
               int alen);
 int addraw_l(struct nlmsghdr *n, int maxlen, const void *data, int len);


### PR DESCRIPTION
Make use of the bulk RTM_DELNEIGH message to properly flush per-vlan
fdbs instead of just globally for MSTI 0 / CIST.