### PR TITLE
netif_utils: fix speeds > 65G

### DIFF
--- a/netif_utils.c
+++ b/netif_utils.c
@@ -117,7 +117,7 @@ int ethtool_get_speed_duplex(char *ifname, int *speed, int *duplex)
         ERROR("Cannot get speed/duplex for %s: %m\n", ifname);
         return -1;
     }
-    *speed = ecmd.speed;   /* Ethtool speed is in Mbps */
+    *speed = ethtool_cmd_speed(&ecmd); /* Ethtool speed is in Mbps */
     *duplex = ecmd.duplex; /* We have same convention as ethtool.
                                0 = half, 1 = full */
     return 0;


### PR DESCRIPTION
ethtool_cmd.speed is a 16 bit value, so the highest representable speed is 65.535 MB/s. For higher speeds, the upper bits are stored in cmd.speed_hi.

But since mstpd was only looking at speed, effectively the speed used was modulo 65536. This broke cost calculation, as a 200G link was now considered a 34.4G link, so its cost rose from expected 100 to 580.

Fix this by using the provided helper, ethtool_cmd_speed().